### PR TITLE
Issues with Browserify And babelify : Updated ethereum block with Latest Version v1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cids": "~0.5.2",
     "eth-hash-to-cid": "~0.1.0",
     "ethereumjs-account": "^2.0.4",
-    "ethereumjs-block": "^1.7.0",
+    "ethereumjs-block": "^1.7.1",
     "ethereumjs-tx": "^1.3.3",
     "ipfs-block": "~0.6.1",
     "merkle-patricia-tree": "^2.2.0",


### PR DESCRIPTION
The earlier version is causing issues with Browserify And babelify

https://github.com/ipfs-shipyard/ipfs-pubsub-room-demo/issues/7

https://github.com/ethereumjs/ethereumjs-block/pull/40

@kumavis @diasdavid Please review and Approve this Fix