### PR TITLE
chore: add module Lead Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 > JavaScript Implementation of the IPLD format - Ethereum Block
 
+## Lead Maintainer
+
+[@kumavis](https://github.com/kumavis)
+
 ## Install
 
 ```sh
@@ -15,10 +19,6 @@
 ## Usage
 
 TBD
-
-## Maintainers
-
-- [@kumavis](https://github.com/kumavis)
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ipld-ethereum",
   "version": "2.0.0",
   "description": "JavaScript Implementation of All Ethereum IPLD formats",
+  "leadMaintainer": "kumavis <aaron@kumavis.me>",
   "main": "src/index.js",
   "scripts": {
     "test": "aegir test",
@@ -19,7 +20,6 @@
     "lint",
     "test"
   ],
-  "author": "kumavis",
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.0",


### PR DESCRIPTION
The Guidelines for the InterPlanetary JavaScript Projects [1] specify
that there is one Lead Maintainer for every module. This commit add
that information to the repository.

[1]: https://github.com/ipfs/community/blob/master/js-code-guidelines.md