### PR TITLE
chore: remove coverage-publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "build": "aegir build",
-    "coverage": "aegir coverage",
-    "coverage-publish": "aegir coverage --provider coveralls"
+    "coverage": "aegir coverage"
   },
   "pre-push": [
     "lint",


### PR DESCRIPTION
Coveralls is no longer used on the CI.

This is part of https://github.com/ipfs/aegir/issues/263.