### PR TITLE
fix: sorting function needs to return an integer

### DIFF
--- a/util/createResolver.js
+++ b/util/createResolver.js
@@ -81,7 +81,7 @@ function createResolver (multicodec, EthObjClass, mapFromEthObject) {
       // only match whole path chunks
       matches = matches.filter((child) => child.path.split('/').every((part, index) => part === pathParts[index]))
       // take longest match
-      const sortedMatches = matches.sort((a, b) => a.path.length < b.path.length)
+      const sortedMatches = matches.sort((a, b) => b.path.length - a.path.length)
       const treeResult = sortedMatches[0]
 
       if (!treeResult) {


### PR DESCRIPTION
The sorting function was returning a boolean, which is wrong.
For proper comparison it needs to return an integer.

Intrestingly enough, this issue only surfaced in the Browser
test run on Windows. There somehow the sorting function of a
two element array gets the second element first, then the
second element.