### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.0",
-    "cids": "~0.5.2",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "ethereumjs-account": "^2.0.4",
     "ethereumjs-block": "^2.1.0",
     "ethereumjs-tx": "^1.3.3",


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs created by this module are base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73