### PR TITLE
chore: update dependencies

### DIFF
--- a/eth-account-snapshot/index.js
+++ b/eth-account-snapshot/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const EthAccount = require('ethereumjs-account')
+const EthAccount = require('ethereumjs-account').default
 const multicodec = require('multicodec')
 
 const cidFromHash = require('../util/cidFromHash')

--- a/eth-account-snapshot/test/resolver.spec.js
+++ b/eth-account-snapshot/test/resolver.spec.js
@@ -6,7 +6,7 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const dagEthAccount = require('../index')
 const resolver = dagEthAccount.resolver
-const Account = require('ethereumjs-account')
+const Account = require('ethereumjs-account').default
 const emptyCodeHash = require('../../util/emptyCodeHash')
 const CID = require('cids')
 const multicodec = require('multicodec')

--- a/eth-state-trie/test/resolver.spec.js
+++ b/eth-state-trie/test/resolver.spec.js
@@ -4,7 +4,7 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const Account = require('ethereumjs-account')
+const Account = require('ethereumjs-account').default
 const Trie = require('merkle-patricia-tree')
 const multicodec = require('multicodec')
 const CID = require('cids')

--- a/eth-tx-trie/test/resolver.spec.js
+++ b/eth-tx-trie/test/resolver.spec.js
@@ -6,7 +6,7 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const CID = require('cids')
 const EthBlock = require('ethereumjs-block')
-const EthTx = require('ethereumjs-tx')
+const EthTx = require('ethereumjs-tx').Transaction
 const multicodec = require('multicodec')
 const promisify = require('promisify-es6')
 const ipldEthTxTrie = require('../index')

--- a/eth-tx/index.js
+++ b/eth-tx/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const EthTx = require('ethereumjs-tx')
+const EthTx = require('ethereumjs-tx').Transaction
 const createResolver = require('../util/createResolver')
 const multicodec = require('multicodec')
 

--- a/eth-tx/test/resolver.spec.js
+++ b/eth-tx/test/resolver.spec.js
@@ -4,7 +4,7 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const Transaction = require('ethereumjs-tx')
+const Transaction = require('ethereumjs-tx').Transaction
 const dagEthTx = require('../index')
 const resolver = dagEthTx.resolver
 const util = dagEthTx.util

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
   "license": "MIT",
   "dependencies": {
     "cids": "~0.7.0",
-    "ethereumjs-account": "^2.0.4",
-    "ethereumjs-block": "^2.1.0",
-    "ethereumjs-tx": "^1.3.3",
+    "ethereumjs-account": "^3.0.0",
+    "ethereumjs-block": "^2.2.1",
+    "ethereumjs-tx": "^2.1.1",
     "merkle-patricia-tree": "^3.0.0",
     "multicodec": "^1.0.0",
-    "multihashes": "~0.4.12",
+    "multihashes": "~0.4.15",
     "multihashing-async": "~0.8.0",
-    "rlp": "^2.0.0"
+    "rlp": "^2.2.4"
   },
   "devDependencies": {
-    "aegir": "^20.0.0",
-    "chai": "^4.1.2",
+    "aegir": "^20.4.1",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "promisify-es6": "^1.0.3"
   },


### PR DESCRIPTION
ethereumjs libraries are using TypeScript which create named and default exports we have to use now

I'm mainly trying to get past the keccak compile errors but ethereumjs-block and merkle-patricia-tree need to update their ethereumjs-util dependency, they're a bit stalled on their interlocked dependencies and their big typescript migration though https://github.com/ethereumjs/ethereumjs-block/pull/74

Here's the problem with this PR though - it doesn't pass on my mac. I get a `uv_close()` assert deep in the guts of Node during test run, somewhat at random but regular enough to not be able to fully pass through Browser + WebWorker tests _most runs_ without crashing (sometimes it gets through, green). I can't work out whether it's an aegir, karma, node, addon (fsevents possibly since it messes around down at that level on macos) or even Chrome version problem. I don't really see why it would be related to the dependency updates so would appreciate someone trying to replicate the problems.

```
Assertion failed: (0), function uv_close, file ../deps/uv/src/unix/core.c, line 187.
```
