### PR TITLE
chore: update deps

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  webpack: {
+    node: {
+      // this is needed until keccak and cipher-base stop using node streams in browser code
+      stream: true,
+
+      // this is needed until core-util-is stops using node buffers in browser code
+      Buffer: true
+    }
+  }
+}

--- a/eth-account-snapshot/index.js
+++ b/eth-account-snapshot/index.js
@@ -1,6 +1,7 @@
 'use strict'
 const EthAccount = require('ethereumjs-account').default
 const multicodec = require('multicodec')
+const { Buffer } = require('buffer')
 
 const cidFromHash = require('../util/cidFromHash')
 const createResolver = require('../util/createResolver')

--- a/eth-account-snapshot/test/resolver.spec.js
+++ b/eth-account-snapshot/test/resolver.spec.js
@@ -10,6 +10,7 @@ const Account = require('ethereumjs-account').default
 const emptyCodeHash = require('../../util/emptyCodeHash')
 const CID = require('cids')
 const multicodec = require('multicodec')
+const { Buffer } = require('buffer')
 
 describe('IPLD format resolver (local)', () => {
   const testData = {

--- a/eth-block/test/resolver.spec.js
+++ b/eth-block/test/resolver.spec.js
@@ -8,6 +8,7 @@ const CID = require('cids')
 const EthBlockHeader = require('ethereumjs-block/header')
 const multihash = require('multihashes')
 const multicodec = require('multicodec')
+const { Buffer } = require('buffer')
 
 const ipldEthBlock = require('../index')
 const resolver = ipldEthBlock.resolver

--- a/eth-state-trie/test/resolver.spec.js
+++ b/eth-state-trie/test/resolver.spec.js
@@ -9,6 +9,7 @@ const Trie = require('merkle-patricia-tree')
 const multicodec = require('multicodec')
 const CID = require('cids')
 const promisify = require('promisify-es6')
+const { Buffer } = require('buffer')
 const ipldEthStateTrie = require('../index')
 const resolver = ipldEthStateTrie.resolver
 

--- a/eth-storage-trie/test/resolver.spec.js
+++ b/eth-storage-trie/test/resolver.spec.js
@@ -8,6 +8,7 @@ const CID = require('cids')
 const Trie = require('merkle-patricia-tree')
 const multicodec = require('multicodec')
 const promisify = require('promisify-es6')
+const { Buffer } = require('buffer')
 const ipldEthStateTrie = require('../index')
 const resolver = ipldEthStateTrie.resolver
 

--- a/eth-tx-trie/test/resolver.spec.js
+++ b/eth-tx-trie/test/resolver.spec.js
@@ -9,6 +9,7 @@ const EthBlock = require('ethereumjs-block')
 const EthTx = require('ethereumjs-tx').Transaction
 const multicodec = require('multicodec')
 const promisify = require('promisify-es6')
+const { Buffer } = require('buffer')
 const ipldEthTxTrie = require('../index')
 const resolver = ipldEthTxTrie.resolver
 

--- a/eth-tx/test/resolver.spec.js
+++ b/eth-tx/test/resolver.spec.js
@@ -10,6 +10,7 @@ const resolver = dagEthTx.resolver
 const util = dagEthTx.util
 const multihash = require('multihashes')
 const multicodec = require('multicodec')
+const { Buffer } = require('buffer')
 
 describe('IPLD format resolver (local)', () => {
   const testData = {

--- a/package.json
+++ b/package.json
@@ -21,18 +21,19 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cids": "~0.8.0",
+    "buffer": "^5.6.0",
+    "cids": "^0.8.3",
     "ethereumjs-account": "^3.0.0",
     "ethereumjs-block": "^2.2.1",
     "ethereumjs-tx": "^2.1.1",
     "merkle-patricia-tree": "^3.0.0",
     "multicodec": "^1.0.0",
-    "multihashes": "~0.4.15",
-    "multihashing-async": "~0.8.0",
+    "multihashes": "^1.0.1",
+    "multihashing-async": "^1.0.0",
     "rlp": "^2.2.4"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "promisify-es6": "^1.0.3"

--- a/util/createResolver.js
+++ b/util/createResolver.js
@@ -1,6 +1,7 @@
 'use strict'
 const CID = require('cids')
 const multicodec = require('multicodec')
+const { Buffer } = require('buffer')
 const createUtil = require('../util/createUtil')
 
 const createResolver = (codec, deserialize) => {

--- a/util/emptyCodeHash.js
+++ b/util/emptyCodeHash.js
@@ -1,2 +1,6 @@
+'use strict'
+
+const { Buffer } = require('buffer')
+
 // this is the hash of the empty code (SHA3_NULL)
 module.exports = Buffer.from('c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470', 'hex')


### PR DESCRIPTION
Updates all deps to the latest version apart from merkle-patricia-tree
as there's been a big refactor between v3 and v4 and I'm not familiar
enough with ethereum to do the necessary refactor confidently.

Adds requires for Buffer to be more friendly to the browser.