### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/eth-account-snapshot/test/resolver.spec.js
+++ b/eth-account-snapshot/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const dagEthAccount = require('../index')
 const resolver = dagEthAccount.resolver
 const Account = require('ethereumjs-account').default

--- a/eth-block-list/test/resolver.spec.js
+++ b/eth-block-list/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const multihash = require('multihashes')
 const multicodec = require('multicodec')

--- a/eth-block/test/resolver.spec.js
+++ b/eth-block/test/resolver.spec.js
@@ -9,6 +9,7 @@ const EthBlockHeader = require('ethereumjs-block/header')
 const multihash = require('multihashes')
 const multicodec = require('multicodec')
 const { Buffer } = require('buffer')
+const uint8ArrayToString = require('uint8arrays/to-string')
 
 const ipldEthBlock = require('../index')
 const resolver = ipldEthBlock.resolver
@@ -51,7 +52,7 @@ describe('IPLD format resolver (local)', () => {
     const reconstructedCid = new CID(encodedCid)
     expect(cid.version).to.equal(reconstructedCid.version)
     expect(cid.codec).to.equal(reconstructedCid.codec)
-    expect(cid.multihash.toString('hex')).to.equal(reconstructedCid.multihash.toString('hex'))
+    expect(uint8ArrayToString(cid.multihash, 'base16')).to.equal(uint8ArrayToString(reconstructedCid.multihash, 'base16'))
   })
 
   describe('resolver.resolve', () => {

--- a/eth-block/test/resolver.spec.js
+++ b/eth-block/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const EthBlockHeader = require('ethereumjs-block/header')
 const multihash = require('multihashes')

--- a/eth-state-trie/test/resolver.spec.js
+++ b/eth-state-trie/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const Account = require('ethereumjs-account').default
 const Trie = require('merkle-patricia-tree')
 const multicodec = require('multicodec')

--- a/eth-storage-trie/test/resolver.spec.js
+++ b/eth-storage-trie/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const Trie = require('merkle-patricia-tree')
 const multicodec = require('multicodec')

--- a/eth-tx-trie/test/resolver.spec.js
+++ b/eth-tx-trie/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const CID = require('cids')
 const EthBlock = require('ethereumjs-block')
 const EthTx = require('ethereumjs-tx').Transaction

--- a/eth-tx/test/resolver.spec.js
+++ b/eth-tx/test/resolver.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const Transaction = require('ethereumjs-tx').Transaction
 const dagEthTx = require('../index')
 const resolver = dagEthTx.resolver

--- a/package.json
+++ b/package.json
@@ -22,21 +22,20 @@
   "license": "MIT",
   "dependencies": {
     "buffer": "^5.6.0",
-    "cids": "^0.8.3",
+    "cids": "^1.0.0",
     "ethereumjs-account": "^3.0.0",
     "ethereumjs-block": "^2.2.1",
     "ethereumjs-tx": "^2.1.1",
     "merkle-patricia-tree": "^3.0.0",
-    "multicodec": "^1.0.0",
-    "multihashes": "^1.0.1",
-    "multihashing-async": "^1.0.0",
+    "multicodec": "^2.0.0",
+    "multihashes": "^3.0.1",
+    "multihashing-async": "^2.0.0",
     "rlp": "^2.2.4"
   },
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "promisify-es6": "^1.0.3"
+    "promisify-es6": "^1.0.3",
+    "uint8arrays": "^1.0.0"
   },
   "contributors": [
     "kumavis <aaron@kumavis.me>",

--- a/util/createResolver.js
+++ b/util/createResolver.js
@@ -1,7 +1,6 @@
 'use strict'
 const CID = require('cids')
 const multicodec = require('multicodec')
-const { Buffer } = require('buffer')
 const createUtil = require('../util/createUtil')
 
 const createResolver = (codec, deserialize) => {
@@ -13,7 +12,7 @@ const createResolver = (codec, deserialize) => {
    * Returns the value or a link and the partial mising path. This way the
    * IPLD Resolver can fetch the link and continue to resolve.
    *
-   * @param {Buffer} binaryBlob - Binary representation of a Ethereum block
+   * @param {Uint8Array} binaryBlob - Binary representation of a Ethereum block
    * @param {string} [path='/'] - Path that should be resolved
    * @returns {Object} result - Result of the path it it was resolved successfully
    * @returns {*} result.value - Value the path resolves to
@@ -48,7 +47,7 @@ const createResolver = (codec, deserialize) => {
 
   const _traverse = function * (node, path) {
     // Traverse only objects and arrays
-    if (Buffer.isBuffer(node) || CID.isCID(node) || typeof node === 'string' ||
+    if (node instanceof Uint8Array || CID.isCID(node) || typeof node === 'string' ||
         node === null) {
       return
     }

--- a/util/createTrieResolver.js
+++ b/util/createTrieResolver.js
@@ -3,7 +3,6 @@ const rlp = require('rlp')
 const EthTrieNode = require('merkle-patricia-tree/trieNode')
 const cidFromHash = require('./cidFromHash')
 const createResolver = require('./createResolver')
-const createUtil = require('./createUtil')
 
 // A `nibble` is an array of nested keys. So for example `[2, 1, 3]` would
 // mean an item with value `"foo"` would be in an object like this:

--- a/util/createUtil.js
+++ b/util/createUtil.js
@@ -9,17 +9,27 @@ const createUtil = (codec, deserialize) => {
     /**
      * Deserialize Ethereum block into the internal representation.
      *
-     * @param {Buffer} serialized - Binary representation of a Ethereum block.
+     * @param {Uint8Array|Array<Uint8Array>} serialized - Binary representation of a Ethereum block.
      * @returns {Object}
      */
-    deserialize,
+    deserialize: (serialized) => {
+      if (Array.isArray(serialized)) {
+        if (!Buffer.isBuffer(serialized[0])) {
+          serialized = serialized.map(s => Buffer.from(s))
+        }
+      } else if (!Buffer.isBuffer(serialized)) {
+        serialized = Buffer.from(serialized)
+      }
+
+      return deserialize(serialized)
+    },
     /**
      * Serialize internal representation into a binary Ethereum block.
      *
      * @param {Object} deserialized - Internal representation of a Bitcoin block
-     * @returns {Buffer}
+     * @returns {Uint8Array}
      */
-    serialize: (deserialized) => deserialized._ethObj.serialize(),
+    serialize: (deserialized) => Uint8Array.from(deserialized._ethObj.serialize()),
     /**
      * Calculate the CID of the binary blob.
      *

--- a/util/createUtil.js
+++ b/util/createUtil.js
@@ -15,10 +15,10 @@ const createUtil = (codec, deserialize) => {
     deserialize: (serialized) => {
       if (Array.isArray(serialized)) {
         if (!Buffer.isBuffer(serialized[0])) {
-          serialized = serialized.map(s => Buffer.from(s))
+          serialized = serialized.map(s => Buffer.from(s, s.byteOffset, s.byteLength))
         }
       } else if (!Buffer.isBuffer(serialized)) {
-        serialized = Buffer.from(serialized)
+        serialized = Buffer.from(serialized, serialized.byteOffset, serialized.byteLength)
       }
 
       return deserialize(serialized)


### PR DESCRIPTION
This module now accepts Uint8Arrays as well as node Buffers and
returns Uint8Arrays.  Internally it converts non-Buffers into Buffers
because the ethereum libs require that.

BREAKING CHANGES:

- `util.cid` returns `CID`s with a breaking API change - see https://github.com/multiformats/js-cid/pull/117 for changes