### PR TITLE
fix: add missing buffer require

### DIFF
--- a/util/createResolver.js
+++ b/util/createResolver.js
@@ -62,7 +62,7 @@ const createResolver = (codec, deserialize) => {
    * Return all available paths of a block.
    *
    * @generator
-   * @param {Buffer} binaryBlob - Binary representation of a Bitcoin block
+   * @param {Uint8Array} binaryBlob - Binary representation of a Bitcoin block
    * @yields {string} - A single path
    */
   const tree = function * (binaryBlob) {

--- a/util/createUtil.js
+++ b/util/createUtil.js
@@ -1,6 +1,7 @@
 const CID = require('cids')
 const multicodec = require('multicodec')
 const multihashing = require('multihashing-async')
+const { Buffer } = require('buffer')
 
 const DEFAULT_HASH_ALG = multicodec.KECCAK_256
 


### PR DESCRIPTION
See https://github.com/ipld/js-ipld-ethereum/pull/69/files#r465473783

Arg type for the `.tree` resolver method was wrong too.